### PR TITLE
Audit for dimensionless.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+.CondaPkg/

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,0 +1,3 @@
+[deps]
+astropy = ""
+plasmapy = ""

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ authors = ["Zijin Zhang", "Luke Adams <luke@lukeclydeadams.com>"]
 version = "0.1.0"
 
 [deps]
+PermuteArgs = "9536dbe3-0ca9-4073-961c-7241c6d3471f"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
 
 [compat]
 Aqua = "0.8"
 LinearAlgebra = "1.10"
+PermuteArgs = "1.2.1"
 Test = "1.10"
 Unitful = "1.0"
 UnitfulEquivalences = "0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
 Aqua = "0.8"
 LinearAlgebra = "1.10"
 PermuteArgs = "1.2.1"
+PythonCall = "0.9.23"
 Test = "1.10"
 Unitful = "1.0"
 UnitfulEquivalences = "0.2"
@@ -20,7 +21,8 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "LinearAlgebra", "Test"]
+test = ["Aqua", "LinearAlgebra", "PythonCall", "Test"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,6 @@
 # API Reference
 
-```@autodocs
-Modules = [PlasmaFormulary]
+## Dimensionless numbers
+```@docs
+plasma_beta
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,3 +4,10 @@
 ```@docs
 plasma_beta
 ```
+
+## Otherwise undocumented functions
+This section will be removed once the documentation is complete.
+```@autodocs
+Modules = [PlasmaFormulary]
+Pages   = ["frequencies.jl", "lengths.jl", "misc.jl", "speeds.jl"]
+```

--- a/src/PlasmaFormulary.jl
+++ b/src/PlasmaFormulary.jl
@@ -1,11 +1,12 @@
 module PlasmaFormulary
 
 using Unitful
-using UnitfulEquivalences
 using Unitful: μ0, ε0, c, q
 using Unitful: k, ħ
 using Unitful: me, mp, u
 using Unitful: Velocity, Mass, BField, Density, Charge
+using UnitfulEquivalences
+using PermuteArgs
 
 @derived_dimension NumberDensity Unitful.𝐋^-3
 

--- a/src/dimensionless.jl
+++ b/src/dimensionless.jl
@@ -8,7 +8,8 @@ Compute the plamsa beta (β), the ratio of thermal pressure to magnetic pressure
 - `n`: The particle density of the plasma.
 - `B`: The magnetic field in the plasma.
 """
-function plasma_beta(T::EnergyOrTemp, n::NumberDensity, B::Unitful.BField)
+function plasma_beta end
+@permute_args function plasma_beta(T::EnergyOrTemp, n::NumberDensity, B::Unitful.BField)
     p_th = thermal_pressure(T, n)
     p_B = magnetic_pressure(B)
     return p_th / p_B |> upreferred

--- a/src/dimensionless.jl
+++ b/src/dimensionless.jl
@@ -7,6 +7,16 @@ Compute the plamsa beta (β), the ratio of thermal pressure to magnetic pressure
 - `T`: The temperature of the plasma.
 - `n`: The particle density of the plasma.
 - `B`: The magnetic field in the plasma.
+
+# Example
+```jldoctest
+julia> plasma_beta(1e6u"K", 1e19u"m^-3", 0.2u"T")
+0.008674873511172188
+```
+
+# References
+- [PlasmaPy Documentation](https://docs.plasmapy.org/en/stable/api/plasmapy.formulary.dimensionless.beta.html)
+- [Wikipedia](https://en.wikipedia.org/wiki/Plasma_beta)
 """
 function plasma_beta end
 @permute_args function plasma_beta(T::EnergyOrTemp, n::NumberDensity, B::Unitful.BField)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,4 +28,14 @@ using LinearAlgebra
         @test plasma_frequency(1e19u"m^-3", 1, Unitful.mp / Unitful.u) ≈ 4163294534.0u"s^-1"
         @test plasma_frequency(1e19u"m^-3") ≈ 1.783986365e11u"s^-1"
     end
+
+    @testset "dimensionless.jl" begin
+        T = 2.0u"eV"
+        n = 1e19u"m^-3"
+        B = 0.1u"T"
+        @test plasma_beta(T, n, B) == plasma_beta(n, B, PlasmaFormulary.temperature(T)) == plasma_beta(n, T, B)
+
+        units = pyimport("astropy.units")
+        formulary = pyimport("plasmapy.formulary")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test
 using Aqua
 using Unitful
 using LinearAlgebra
+using PythonCall
+
+units = pyimport("astropy.units")
+formulary = pyimport("plasmapy.formulary")
 
 @testset "PlasmaFormulary.jl" begin
     @testset "Code quality (Aqua.jl)" begin
@@ -35,7 +39,6 @@ using LinearAlgebra
         B = 0.1u"T"
         @test plasma_beta(T, n, B) == plasma_beta(n, B, PlasmaFormulary.temperature(T)) == plasma_beta(n, T, B)
 
-        units = pyimport("astropy.units")
-        formulary = pyimport("plasmapy.formulary")
+        @test pyconvert(Float64, pyfloat(formulary.lengths.Debye_length(10 * units.eV, 1e19 / units.m^3) / units.m)) ≈ ustrip(u"m", PlasmaFormulary.debye_length(1e19 * u"m^-3", 10 * u"eV")) rtol=1e-3
     end
 end


### PR DESCRIPTION
- [x] Item input/output uses Unitful.jl to keep track of units
- [x] Particle quantities can be specified using ChargedParticles.jl, if applicable
- [x] Arguments are order independent, or it is documented clearly that this is not the case
- [x] Output tested against known good examples, either using doctests or in the package tests
- [x] Output tested against plasmapy, if possible.
- [x] Docstring with a description of the physical meaning of the quantity, a doctest example, cross references, external references to e.g. Wikipedia, plasmapy, etc.
- [x] Item is included in the appropriate section of the docs.

