### PR TITLE
Audit for frequencies.jl : gyrofrequency and plasma_frequency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    tags: ['*']
+    tags: ["*"]
   pull_request:
   workflow_dispatch:
 concurrency:
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
-          - 'pre'
+          - "1.10"
+          - "pre"
         os:
           - ubuntu-latest
         arch:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
+          version: "1"
       - uses: julia-actions/cache@v2
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
@@ -67,5 +67,5 @@ jobs:
         run: |
           using Documenter: DocMeta, doctest
           using PlasmaFormulary
-          DocMeta.setdocmeta!(PlasmaFormulary, :DocTestSetup, :(using PlasmaFormulary, Unitful); recursive=true)
+          DocMeta.setdocmeta!(PlasmaFormulary, :DocTestSetup, :(using PlasmaFormulary, Unitful, DimensionfulAngles); recursive=true)
           doctest(PlasmaFormulary)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,10 +62,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - name: Run doctests
-        shell: julia --project=docs --color=yes {0}
-        run: |
-          using Documenter: DocMeta, doctest
-          using PlasmaFormulary
-          DocMeta.setdocmeta!(PlasmaFormulary, :DocTestSetup, :(using PlasmaFormulary, Unitful, DimensionfulAngles); recursive=true)
-          doctest(PlasmaFormulary)

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,15 @@ authors = ["Zijin Zhang", "Luke Adams <luke@lukeclydeadams.com>"]
 version = "0.1.0"
 
 [deps]
+ChargedParticles = "e91dad46-2c06-47f2-8668-7ffa57fde2d9"
 PermuteArgs = "9536dbe3-0ca9-4073-961c-7241c6d3471f"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
 
 [compat]
+Aqua = "0.8"
+ChargedParticles = "0.3.0"
+LinearAlgebra = "1.10"
 PermuteArgs = "1.2.1"
 Unitful = "1.0"
 UnitfulEquivalences = "0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,8 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
 
 [compat]
-Aqua = "0.8"
 ChargedParticles = "0.3.0"
 DimensionfulAngles = "0.2.1"
-LinearAlgebra = "1.10"
 PermuteArgs = "1.2.1"
 Unitful = "1.0"
 UnitfulEquivalences = "0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ChargedParticles = "e91dad46-2c06-47f2-8668-7ffa57fde2d9"
+DimensionfulAngles = "2d4b8d7a-02d9-40f9-9abe-9c695b77de0d"
 PermuteArgs = "9536dbe3-0ca9-4073-961c-7241c6d3471f"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
@@ -12,6 +13,7 @@ UnitfulEquivalences = "da9c4bc3-91c8-4f02-8a40-6b990d2a7e0c"
 [compat]
 Aqua = "0.8"
 ChargedParticles = "0.3.0"
+DimensionfulAngles = "0.2.1"
 LinearAlgebra = "1.10"
 PermuteArgs = "1.2.1"
 Unitful = "1.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DimensionfulAngles = "2d4b8d7a-02d9-40f9-9abe-9c695b77de0d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PlasmaFormulary = "d26ff896-aba2-4e70-a0a6-448627456efe"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using Documenter
 DocMeta.setdocmeta!(
     PlasmaFormulary,
     :DocTestSetup,
-    :(using PlasmaFormulary, Unitful);
+    :(using PlasmaFormulary, Unitful, DimensionfulAngles);
     recursive = true,
 )
 
@@ -12,6 +12,11 @@ makedocs(;
     modules = [PlasmaFormulary],
     sitename = "PlasmaFormulary.jl",
     pages = ["Home" => "index.md", "API Reference" => "api.md"],
+    doctest = true,
 )
 
-deploydocs(; repo = "github.com/JuliaPlasma/PlasmaFormulary.jl", devbranch = "main", push_preview = true)
+deploydocs(;
+    repo = "github.com/JuliaPlasma/PlasmaFormulary.jl",
+    devbranch = "main",
+    push_preview = true,
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,9 +5,16 @@
 plasma_beta
 ```
 
+## Plasma frequency parameters
+
+```@docs
+plasma_frequency
+gyrofrequency
+```
+
 ## Otherwise undocumented functions
 This section will be removed once the documentation is complete.
 ```@autodocs
 Modules = [PlasmaFormulary]
-Pages   = ["frequencies.jl", "lengths.jl", "misc.jl", "speeds.jl"]
+Pages   = ["lengths.jl", "misc.jl", "speeds.jl"]
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,7 +5,7 @@
 plasma_beta
 ```
 
-## Plasma frequency parameters
+## Frequencies
 
 ```@docs
 plasma_frequency

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,6 +18,10 @@ This package implements a subset of the formulas found in the [NRL Plasma Formul
 using PlasmaFormulary, Unitful
 
 PlasmaFormulary.debye_length(1e18u"cm^-3", 10u"eV")
+
+gyrofrequency(0.01u"T", :e) # electron gyrofrequency
+
+plasma_frequency(1e19u"m^-3", "proton") # proton plasma frequency
 ```
 
 ## Installation

--- a/src/PlasmaFormulary.jl
+++ b/src/PlasmaFormulary.jl
@@ -61,7 +61,7 @@ include("speeds.jl")
 export alfven_velocity, thermal_velocity, thermal_temperature, electron_thermal_velocity
 
 include("frequencies.jl")
-export gyrofrequency, electron_gyrofrequency, ion_gyrofrequency, plasma_frequency
+export gyrofrequency, plasma_frequency
 
 include("misc.jl")
 export thermal_pressure, magnetic_pressure

--- a/src/PlasmaFormulary.jl
+++ b/src/PlasmaFormulary.jl
@@ -6,9 +6,10 @@ using Unitful: k, ħ
 using Unitful: me, mp, u
 using Unitful: Velocity, Mass, BField, Density, Charge
 using UnitfulEquivalences
+using DimensionfulAngles: radᵃ as rad
 using PermuteArgs
 using ChargedParticles
-using ChargedParticles:ParticleLike
+using ChargedParticles: ParticleLike
 
 @derived_dimension NumberDensity Unitful.𝐋^-3
 

--- a/src/PlasmaFormulary.jl
+++ b/src/PlasmaFormulary.jl
@@ -7,6 +7,8 @@ using Unitful: me, mp, u
 using Unitful: Velocity, Mass, BField, Density, Charge
 using UnitfulEquivalences
 using PermuteArgs
+using ChargedParticles
+using ChargedParticles:ParticleLike
 
 @derived_dimension NumberDensity Unitful.𝐋^-3
 

--- a/src/frequencies.jl
+++ b/src/frequencies.jl
@@ -1,5 +1,33 @@
-function gyrofrequency(B::BField, mass::Mass, q::Charge)
-    upreferred(q * B / mass)
+"""
+    gyrofrequency(B::BField, p::ParticleLike; kw...)
+
+Calculate the gyrofrequency (or cyclotron frequency) of a charged particle's circular motion in a magnetic field.
+The gyrofrequency is the frequency of a charged particle's gyromotion around magnetic field lines.
+
+References: 
+- [PlasmaPy Documentation](https://docs.plasmapy.org/en/latest/api/plasmapy.formulary.frequencies.gyrofrequency.html)
+
+# Examples
+```jldoctest; filter = r"(\\^-1|⁻¹)"
+julia> gyrofrequency(0.01u"T", :p)  # proton gyrofrequency
+957883.3292211705 s⁻¹
+
+julia> gyrofrequency(0.1u"T", :e)  # electron gyrofrequency
+1.7588200107721634e10 s⁻¹
+
+julia> gyrofrequency(250u"Gauss", "Fe"; z=13)  # Fe2+ ion gyrofrequency
+560682.3520611608 s⁻¹
+```
+"""
+function gyrofrequency end
+
+@permute_args function gyrofrequency(B::BField, mass::Mass, q::Charge)
+    upreferred(abs(q * B / mass))
+end
+
+@permute_args function gyrofrequency(B::BField, p::ParticleLike; kw...)
+    p = particle(p; kw...)
+    return gyrofrequency(B, mass(p), charge(p))
 end
 
 function electron_gyrofrequency(B::BField)
@@ -11,27 +39,41 @@ function ion_gyrofrequency(B::BField, Z, mass::Mass)
 end
 
 """
-    plasma_frequency(n, [q, mass])
+    plasma_frequency(n::NumberDensity, [q::Charge, mass::Mass])
+    plasma_frequency(n::NumberDensity, p::ParticleLike; kw...)
+    plasma_frequency(n::NumberDensity, Z::Integer, mass_numb)
 
-Particle plasma frequency, often this is the cold electrons plasma frequency.
+Calculate the plasma frequency of a species.
 
-References:
-- https://en.wikipedia.org/wiki/Plasma_oscillation
+The plasma frequency is a characteristic frequency of the plasma. 
+More often, it refers to the frequency at which electrons oscillate in the plasma.
+
+# Examples
+```jldoctest; filter = r"(\\^-1|⁻¹)"
+julia> plasma_frequency(1e19u"m^-3")  # plasma frequency
+1.7839863654934653e11 s⁻¹
+
+julia> plasma_frequency(1e19u"m^-3", :p)  # proton plasma frequency
+4.163294562488352e9 s⁻¹
+```
+
+# References
+- [Wikipedia](https://en.wikipedia.org/wiki/Plasma_oscillation)
+- [PlasmaPy Documentation](https://docs.plasmapy.org/en/latest/api/plasmapy.formulary.frequencies.plasma_frequency.html)
 """
-function plasma_frequency(n::NumberDensity, q::Charge, mass::Mass)
-    upreferred(q * sqrt(n / mass / ε0))
+function plasma_frequency end
+
+@permute_args function plasma_frequency(n::NumberDensity, q::Charge, mass::Mass)
+    abs(q) * sqrt(n / mass / ε0) |> upreferred
 end
+
+@permute_args function plasma_frequency(n::NumberDensity, p::ParticleLike; kw...)
+    p = particle(p; kw...)
+    return plasma_frequency(n, charge(p), mass(p))
+end
+
 
 plasma_frequency(n::NumberDensity) = plasma_frequency(n, Unitful.q, me)
 
-"""
-    plasma_frequency(n, Z, mass_numb)
-
-Ion plasma frequency.
-"""
 plasma_frequency(n::NumberDensity, Z::Integer, mass_number) =
     plasma_frequency(n, Z * Unitful.q, mass_number * Unitful.u)
-
-# TODO: Do we need these?
-const electron_plasma_frequency = plasma_frequency
-const ion_plasma_frequency = plasma_frequency

--- a/src/frequencies.jl
+++ b/src/frequencies.jl
@@ -54,7 +54,7 @@ julia> plasma_frequency(1e19u"m^-3")  # plasma frequency
 1.7839863654934653e11 s⁻¹
 
 julia> plasma_frequency(1e19u"m^-3", :p)  # proton plasma frequency
-4.163294562488352e9 s⁻¹
+4.1632945624883513e9 s⁻¹
 ```
 
 # References

--- a/src/frequencies.jl
+++ b/src/frequencies.jl
@@ -3,7 +3,7 @@
     gyrofrequency(B::BField, mass::Mass, q::Charge)
 
 Calculate the gyrofrequency (or cyclotron frequency) of a charged particle's circular motion in a magnetic field.
-The gyrofrequency is the frequency of a charged particle's gyromotion around magnetic field lines.
+The gyrofrequency is the angular frequency of a charged particle's gyromotion around magnetic field lines.
 
 References: 
 - [PlasmaPy Documentation](https://docs.plasmapy.org/en/latest/api/plasmapy.formulary.frequencies.gyrofrequency.html)
@@ -11,19 +11,19 @@ References:
 # Examples
 ```jldoctest; filter = r"(\\^-1|⁻¹)"
 julia> gyrofrequency(0.01u"T", :p)  # proton gyrofrequency
-957883.3292211705 s⁻¹
+957883.3292211705 rad s⁻¹
 
-julia> gyrofrequency(0.1u"T", :e)  # electron gyrofrequency
-1.7588200107721634e10 s⁻¹
+julia> uconvert(u"Hz", gyrofrequency(0.1u"T", :e), Periodic())  # electron gyrofrequency as frequency
+2.799248987233304e9 Hz
 
 julia> gyrofrequency(250u"Gauss", "Fe"; z=13)  # Fe2+ ion gyrofrequency
-560682.3520611608 s⁻¹
+560682.3520611608 rad s⁻¹
 ```
 """
 function gyrofrequency end
 
 @permute_args function gyrofrequency(B::BField, mass::Mass, q::Charge)
-    upreferred(abs(q * B / mass))
+    upreferred(rad * abs(q * B / mass))
 end
 
 @permute_args function gyrofrequency(B::BField, p::ParticleLike; kw...)
@@ -43,10 +43,10 @@ More often, it refers to the frequency at which electrons oscillate in the plasm
 # Examples
 ```jldoctest; filter = r"(\\^-1|⁻¹)"
 julia> plasma_frequency(1e19u"m^-3")  # plasma frequency
-1.7839863654934653e11 s⁻¹
+1.7839863654934653e11 rad s⁻¹
 
 julia> plasma_frequency(1e19u"m^-3", :p)  # proton plasma frequency
-4.1632945624883513e9 s⁻¹
+4.1632945624883513e9 rad s⁻¹
 ```
 
 # References
@@ -56,7 +56,7 @@ julia> plasma_frequency(1e19u"m^-3", :p)  # proton plasma frequency
 function plasma_frequency end
 
 @permute_args function plasma_frequency(n::NumberDensity, q::Charge, mass::Mass)
-    abs(q) * sqrt(n / mass / ε0) |> upreferred
+    rad * abs(q) * sqrt(n / mass / ε0) |> upreferred
 end
 
 @permute_args function plasma_frequency(n::NumberDensity, p::ParticleLike; kw...)

--- a/src/frequencies.jl
+++ b/src/frequencies.jl
@@ -1,5 +1,6 @@
 """
     gyrofrequency(B::BField, p::ParticleLike; kw...)
+    gyrofrequency(B::BField, mass::Mass, q::Charge)
 
 Calculate the gyrofrequency (or cyclotron frequency) of a charged particle's circular motion in a magnetic field.
 The gyrofrequency is the frequency of a charged particle's gyromotion around magnetic field lines.
@@ -30,18 +31,9 @@ end
     return gyrofrequency(B, mass(p), charge(p))
 end
 
-function electron_gyrofrequency(B::BField)
-    gyrofrequency(B, me, Unitful.q)
-end
-
-function ion_gyrofrequency(B::BField, Z, mass::Mass)
-    gyrofrequency(B, mass, Z * Unitful.q)
-end
-
 """
     plasma_frequency(n::NumberDensity, [q::Charge, mass::Mass])
     plasma_frequency(n::NumberDensity, p::ParticleLike; kw...)
-    plasma_frequency(n::NumberDensity, Z::Integer, mass_numb)
 
 Calculate the plasma frequency of a species.
 
@@ -72,8 +64,4 @@ end
     return plasma_frequency(n, charge(p), mass(p))
 end
 
-
 plasma_frequency(n::NumberDensity) = plasma_frequency(n, Unitful.q, me)
-
-plasma_frequency(n::NumberDensity, Z::Integer, mass_number) =
-    plasma_frequency(n, Z * Unitful.q, mass_number * Unitful.u)

--- a/src/lengths.jl
+++ b/src/lengths.jl
@@ -19,7 +19,8 @@ function gyroradius(B::BField, mass::Mass, q::Charge, T::EnergyOrTemp)
 end
 
 electron_gyroradius(B::BField, Vperp::Velocity) = gyroradius(B, me, Unitful.q, Vperp)
-electron_gyroradius(B::BField, T::EnergyOrTemp) = electron_gyroradius(B, thermal_velocity(T, me))
+electron_gyroradius(B::BField, T::EnergyOrTemp) =
+    electron_gyroradius(B, thermal_velocity(T, me))
 
 function electron_debroglie_length(eot::EnergyOrTemp)
     upreferred(sqrt(2 * pi * ħ^2 / me / energy(eot)))
@@ -35,7 +36,13 @@ The inertial length is the characteristic length scale for a particle to be acce
 References: [PlasmaPy API Documentation](https://docs.plasmapy.org/en/latest/api/plasmapy.formulary.lengths.inertial_length.html)
 """
 function inertial_length(n::NumberDensity, q::Charge, mass::Mass)
-    upreferred(c / plasma_frequency(n, q, mass))
+    ω_p = uconvert(:Unitful, plasma_frequency(n, q, mass))
+    upreferred(c / ω_p)
+end
+
+function inertial_length(n::NumberDensity, p::ParticleLike; kw...)
+    p = particle(p; kw...)
+    return inertial_length(n, charge(p), mass(p))
 end
 
 electron_inertial_length(n::NumberDensity) = upreferred(c / plasma_frequency(n))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,6 +4,8 @@ CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
+DimensionfulAngles = "2d4b8d7a-02d9-40f9-9abe-9c695b77de0d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/frequencies.jl
+++ b/test/frequencies.jl
@@ -1,6 +1,11 @@
-@testset "Frequency" begin
+using PlasmaFormulary
+using Test
+using Unitful
+using DimensionfulAngles
 
-    @test gyrofrequency(0.01u"T", :p) ≈ 957883.3292211705u"s^-1"
-    @test plasma_frequency(1e19u"m^-3", :p) ≈ 4163294534.0u"s^-1"
-    @test plasma_frequency(1e19u"m^-3") ≈ 1.783986365e11u"s^-1"
+@testset "Frequency" begin
+    @test gyrofrequency(0.01u"T", :p) ≈ 957883.3292211705u"radᵃ*s^-1"
+    @test uconvert(u"Hz", gyrofrequency(0.1u"T", :e), Periodic()) ≈ 2.799248987233304e9u"Hz"
+    @test plasma_frequency(1e19u"m^-3", :p) ≈ 4163294534.0u"radᵃ*s^-1"
+    @test plasma_frequency(1e19u"m^-3") ≈ 1.783986365e11u"radᵃ*s^-1"
 end

--- a/test/frequencies.jl
+++ b/test/frequencies.jl
@@ -1,9 +1,7 @@
-using PlasmaFormulary
-using Test
 using Unitful
-using DimensionfulAngles
 
-@testset "Frequency" begin
+@testitem "Frequency" begin
+    using DimensionfulAngles
     @test gyrofrequency(0.01u"T", :p) ≈ 957883.3292211705u"radᵃ*s^-1"
     @test uconvert(u"Hz", gyrofrequency(0.1u"T", :e), Periodic()) ≈ 2.799248987233304e9u"Hz"
     @test plasma_frequency(1e19u"m^-3", :p) ≈ 4163294534.0u"radᵃ*s^-1"

--- a/test/frequencies.jl
+++ b/test/frequencies.jl
@@ -1,0 +1,4 @@
+@testset "Frequency" begin
+    @test plasma_frequency(1e19u"m^-3", :p) ≈ 4163294534.0u"s^-1"
+    @test plasma_frequency(1e19u"m^-3") ≈ 1.783986365e11u"s^-1"
+end

--- a/test/frequencies.jl
+++ b/test/frequencies.jl
@@ -1,4 +1,6 @@
 @testset "Frequency" begin
+
+    @test gyrofrequency(0.01u"T", :p) ≈ 957883.3292211705u"s^-1"
     @test plasma_frequency(1e19u"m^-3", :p) ≈ 4163294534.0u"s^-1"
     @test plasma_frequency(1e19u"m^-3") ≈ 1.783986365e11u"s^-1"
 end

--- a/test/length.jl
+++ b/test/length.jl
@@ -1,0 +1,5 @@
+@testitem "Length" begin
+    using Unitful
+    @test inertial_length(5u"m^-3", :e) ≈ 2376534.75u"m"
+    @test inertial_length(5u"m^-3", :"He+") ≈ 2.02985e8u"m" rtol = 0.0001
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using PlasmaFormulary
 using Test
-using Aqua
+using TestItems, TestItemRunner
 using Unitful
 using LinearAlgebra
 using PythonCall
@@ -14,7 +14,8 @@ units = pyimport("astropy.units")
 formulary = pyimport("plasmapy.formulary")
 
 @testset "PlasmaFormulary.jl" begin
-    @testset "Code quality (Aqua.jl)" begin
+    @testitem "Code quality (Aqua.jl)" begin
+        using Aqua
         Aqua.test_all(PlasmaFormulary)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,4 +45,5 @@ formulary = pyimport("plasmapy.formulary")
     end
 
     include("frequencies.jl")
+    include("length.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,4 +44,6 @@ formulary = pyimport("plasmapy.formulary")
 
         @test pyconvert(Float64, pyfloat(formulary.lengths.Debye_length(10 * units.eV, 1e19 / units.m^3) / units.m)) ≈ ustrip(u"m", PlasmaFormulary.debye_length(1e19 * u"m^-3", 10 * u"eV")) rtol=1e-3
     end
+
+    include("frequencies.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,9 +31,6 @@ formulary = pyimport("plasmapy.formulary")
               43185.625u"m/s"
 
         @test alfven_velocity.(B, rho) ≈ [-43185.625u"m/s", 0.0u"m/s", 0.0u"m/s"]
-        @test plasma_frequency(1e19u"m^-3", Unitful.q, Unitful.mp) ≈ 4163294534.0u"s^-1"
-        @test plasma_frequency(1e19u"m^-3", 1, Unitful.mp / Unitful.u) ≈ 4163294534.0u"s^-1"
-        @test plasma_frequency(1e19u"m^-3") ≈ 1.783986365e11u"s^-1"
     end
 
     @testset "dimensionless.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ using CondaPkg
 
 CondaPkg.add(["astropy", "plasmapy"])
 
+include("test_utils.jl")
+
 units = pyimport("astropy.units")
 formulary = pyimport("plasmapy.formulary")
 
@@ -39,7 +41,7 @@ formulary = pyimport("plasmapy.formulary")
         B = 0.1u"T"
         @test plasma_beta(T, n, B) == plasma_beta(n, B, PlasmaFormulary.temperature(T)) == plasma_beta(n, T, B)
 
-        @test pyconvert(Float64, pyfloat(formulary.lengths.Debye_length(10 * units.eV, 1e19 / units.m^3) / units.m)) ≈ ustrip(u"m", PlasmaFormulary.debye_length(1e19 * u"m^-3", 10 * u"eV")) rtol=1e-3
+        @test pyustrip(units.m, formulary.lengths.Debye_length(10 * units.eV, 1e19 / units.m^3)) ≈ ustrip(u"m", PlasmaFormulary.debye_length(1e19 * u"m^-3", 10 * u"eV")) rtol=1e-3
     end
 
     include("frequencies.jl")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,1 @@
+pyustrip(unit, val) = pyconvert(Float64, pyfloat(val / unit))


### PR DESCRIPTION
- [x] Item input/output uses Unitful.jl to keep track of units
- [x] Particle quantities can be specified using ChargedParticles.jl, if applicable
- [x]  Arguments are order independent, or it is documented clearly that this is not the case
- [x]  Output tested against known good examples, either using doctests or in the package tests
- [ ]  Output tested against plasmapy, if possible.
- [x]  Docstring with a description of the physical meaning of the quantity, a doctest example, cross references, external references to e.g. Wikipedia, plasmapy, etc.
- [x]  Item is included in the appropriate section of the docs.